### PR TITLE
Update sorting of eigenvectors and eigenvalues

### DIFF
--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -245,7 +245,7 @@ class FactorAnalyzer:
         sstar = np.dot(np.dot(sc, corr_mtx), sc)
 
         # get the eigenvalues and eigenvectors for n_factors
-        values, _ = np.linalg.eigh(sstar)
+        values, _ = sp.linalg.eigh(sstar)
         values = values[::-1][n_factors:]
 
         # calculate the error


### PR DESCRIPTION
This is a PR to address the sorting of eigenvalues and eigenvectors. In some cases, only eigenvalues were being sorted in descending order, and not the associated eigenvectors. 

Resolved this issue by using [`scipy.linalg.eigh`](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.linalg.eigh.html) -- which automatically sorts all eigenvalues and associated eigenvectors in ascending order -- and then reversing the arrays: 

```
e_values, e_vectors = sp.linalg.eigh(corr)
e_values, e_vectors = e_values[::-1], e_vectors[:, ::-1]
``` 

We were previously using [`scipy.linalg.eig`](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.linalg.eig.html), which does not _necessarily_ return sorted eigenvalues. Because all of our matrices are symmetric, and we only want the real parts of the matrix to be considered anyway, it makes sense to use `eigh`.

*Question*: Should we add any additional tests? Since `scipy.linalg.eig` will typically yield properly-sorted eigenvalues up to a point, maybe we should create a few test cases with a higher number of factors? I can add if you think this is worth it.

In addition to this bugfix, a note has been added to indicate that using the maximum likelihoood solution (`method='ml'`) will generate results similar to R's `factanal()` function, rather than the `fa()` function.