### PR TITLE
Add KMO statistics to `factor_analyzer`

### DIFF
--- a/factor_analyzer/__init__.py
+++ b/factor_analyzer/__init__.py
@@ -5,4 +5,5 @@
 """
 
 from .factor_analyzer import (FactorAnalyzer,
-                              calculate_bartlett_sphericity)
+                              calculate_bartlett_sphericity,
+                              calculate_kmo)

--- a/factor_analyzer/analyze.py
+++ b/factor_analyzer/analyze.py
@@ -10,8 +10,9 @@ Factor analysis command line script.
 import os
 import argparse
 import logging
+import pandas as pd
 
-from factor_analyzer.factor_analyzer import FactorAnalyzer, read_file
+from factor_analyzer.factor_analyzer import FactorAnalyzer
 
 
 def main():
@@ -46,7 +47,10 @@ def main():
 
     file_path = args.feature_file
 
-    data = read_file(file_path)
+    if not file_path.lower().endswith('.csv'):
+        raise ValueError('The feature file must be in CSV format.')
+
+    data = pd.read_csv(file_path)
 
     # get the logger
     logger = logging.getLogger(__name__)

--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -19,35 +19,135 @@ from sklearn.preprocessing import scale
 from sklearn.linear_model import LinearRegression
 
 
-def read_file(file_path):
+def covariance_to_correlation(m):
     """
-    A helper function to read file in
-    CSV or TSV format into a data_frame.
+    This is a port of the R `cov2cor` function.
 
     Parameters
     ----------
-    file_path : str
-        The path to a CSV or TSV file.
+    m : numpy array
+        The covariance matrix.
 
     Returns
     -------
-    data : pd.DataFrame
-        The data file read into a pandas data_frame.
+    retval : numpy array
+        The cross-correlation matrix.
 
     Raises
     ------
     ValueError
-        If the file is not CSV, TSV.
+        If the input matrix is not square.
     """
-    # read file in format CSV, TSV
-    if file_path.lower().endswith('.csv'):
-        data = pd.read_csv(file_path)
-    elif file_path.lower().endswith('.tsv'):
-        data = pd.read_csv(file_path, sep='\t')
+
+    # make sure the matrix is square
+    numrows, numcols = m.shape
+    if not numrows == numcols:
+        raise ValueError('Input matrix must be square')
+
+    Is = np.sqrt(1 / np.diag(m))
+    retval = Is * m * np.repeat(Is, numrows).reshape(numrows, numrows)
+    np.fill_diagonal(retval, 1.0)
+    return retval
+
+
+def partial_correlations(data):
+    """
+    This is a python port of the `pcor` function implemented in
+    the `ppcor` R package, which computes partial correlations
+    of each pair of variables in the given data frame `data`,
+    excluding all other variables.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Data frame containing the feature values.
+
+    Returns
+    -------
+    df_pcor : pd.DataFrame
+        Data frame containing the partial correlations of of each
+        pair of variables in the given data frame `df`,
+        excluding all other variables.
+    """
+    numrows, numcols = data.shape
+    df_cov = data.cov()
+    columns = df_cov.columns
+
+    # return a matrix of nans if the number of columns is
+    # greater than the number of rows. When the ncol == nrows
+    # we get the degenerate matrix with 1 only. It is not meaningful
+    # to compute partial correlations when ncol > nrows.
+
+    # create empty array for when we cannot compute the
+    # matrix inversion
+    empty_array = np.empty((len(columns), len(columns)))
+    empty_array[:] = np.nan
+    if numcols > numrows:
+        icvx = empty_array
     else:
-        raise ValueError('The file must be either CSV or TSV format. '
-                         'You have specified the following : {}'.format(file_path))
-    return data
+        # we also return nans if there is singularity in the data
+        # (e.g. all human scores are the same)
+        try:
+            icvx = np.linalg.inv(df_cov)
+        except np.linalg.LinAlgError:
+            icvx = empty_array
+    pcor = -1 * covariance_to_correlation(icvx)
+    np.fill_diagonal(pcor, 1.0)
+    df_pcor = pd.DataFrame(pcor, columns=columns, index=columns)
+    return df_pcor
+
+
+def calculate_kmo(data):
+    """
+    Calculate the Kaiser-Meyer-Olkin criterion
+    for items and overall. This statistic represents
+    the degree to which each observed variable is
+    predicted, without error, by the other variables
+    in the dataset. In general, a KMO < 0.6 is considered
+    inadequate.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        The data frame from which to calculate KMOs.
+
+    Returns
+    -------
+    kmo_per_variable : pd.DataFrame
+        The KMO score per item.
+    kmo_total : float
+        The KMO score overall.
+    """
+
+    # calculate the partial correlations
+    partial_corr = partial_correlations(data)
+    partial_corr = partial_corr.as_matrix()
+
+    # calcualte the pair-wise correlations
+    corr = data.corr()
+    corr = corr.as_matrix()
+
+    # fill matrix diagonals with zeros
+    # and square all elements
+    np.fill_diagonal(corr, 0)
+    np.fill_diagonal(partial_corr, 0)
+
+    partial_corr = partial_corr**2
+    corr = corr**2
+
+    # calculate KMO per item
+    partial_corr_sum = partial_corr.sum(0)
+    corr_sum = corr.sum(0)
+    kmo_per_item = corr_sum / (corr_sum + partial_corr_sum)
+    kmo_per_item = pd.DataFrame(kmo_per_item,
+                                index=data.columns,
+                                columns=['KMO'])
+
+    # calculate KMO overall
+    corr_sum_total = corr.sum()
+    partial_corr_sum_total = partial_corr.sum()
+    kmo_total = corr_sum_total / (corr_sum_total + partial_corr_sum_total)
+    return kmo_per_item, kmo_total
 
 
 def calculate_bartlett_sphericity(data):
@@ -68,12 +168,12 @@ def calculate_bartlett_sphericity(data):
     Parameters
     ----------
     data : pd.DataFrame
-        The data to analyze.
+        The data frame from which to calculate sphericity.
 
     Returns
     -------
     chi_square : float
-        The chi-square value
+        The chi-square value.
     p_value : float
         The p-value for the test.
     """

--- a/tests/test_factor_analyzer.py
+++ b/tests/test_factor_analyzer.py
@@ -49,12 +49,9 @@ def test_calculate_kmo():
     expected_by_item = pd.DataFrame(values,
                                     columns=['KMO'],
                                     index=index)
-    print(expected_by_item)
 
     (kmo_by_item,
      kmo_overall) = calculate_kmo(data)
-
-    print(kmo_by_item)
 
     assert_almost_equal(kmo_by_item, expected_by_item)
     assert_almost_equal(kmo_overall, expected_overall)
@@ -95,48 +92,45 @@ def test_partial_correlations():
                             index=[0, 1, 2])
 
     result = partial_correlations(data)
-
     assert_almost_equal(result, expected)
 
 
 def test_partial_correlations_num_columns_greater():
 
+    # columns greater than rows
     data = pd.DataFrame([[23, 12, 23],
                          [42, 25, 21]])
 
-    empty_array = [[1.0, np.nan, np.nan],
-                   [np.nan, 1.0, np.nan],
-                   [np.nan, np.nan, 1.0]]
+    empty_array = np.empty((3, 3))
+    empty_array[:] = np.nan
+    np.fill_diagonal(empty_array, 1.0)
 
     expected = pd.DataFrame(empty_array,
                             columns=[0, 1, 2],
                             index=[0, 1, 2])
 
     result = partial_correlations(data)
-
     assert_almost_equal(result, expected)
 
 
-def test_partial_correlations_linalgerror():
+def test_partial_correlations_catch_linalgerror():
 
-    # Covariance matrix will be singular
+    # Covariance matrix that will be singular
     data = pd.DataFrame([[10, 10, 10, 10],
                          [12, 12, 12, 12],
                          [15, 15, 15, 15],
                          [20, 20, 20, 20],
                          [11, 11, 11, 11]])
 
-    empty_array = [[1.0, np.nan, np.nan, np.nan],
-                   [np.nan, 1.0, np.nan, np.nan],
-                   [np.nan, np.nan, 1.0, np.nan],
-                   [np.nan, np.nan, np.nan, 1.0]]
+    empty_array = np.empty((4, 4))
+    empty_array[:] = np.nan
+    np.fill_diagonal(empty_array, 1.0)
 
     expected = pd.DataFrame(empty_array,
                             columns=[0, 1, 2, 3],
                             index=[0, 1, 2, 3])
 
     result = partial_correlations(data)
-
     assert_almost_equal(result, expected)
 
 


### PR DESCRIPTION
The primary purpose of this PR is to add Kaiser-Meyer-Olkin (KMO) statistics to `factor_analyzer`. These statistics are widely used in exploratory factor analysis (EFA) to assess whether a dataset is well-suited to EFA.

- Removed `read_file()` function, as well as associated tests.
- Added `covariance_to_correlation()` and `partial_correlations()` functions, as well as associated tests.
- Added `calculate_kmo()` function, as well as associated tests.

**Note:** I was originally planning to incorporate scree plots as well, but decided to leave these out for now.