### PR TITLE
HotFix: Add `self` to `fit()` method in CFA

### DIFF
--- a/conda-recipe/factor_analyzer/meta.yaml
+++ b/conda-recipe/factor_analyzer/meta.yaml
@@ -21,18 +21,18 @@ build:
 
 requirements:
   build:
-    - python ==3.6
+    - python==3.6
     - setuptools
     - pandas
-    - scipy=1.2.1
-    - numpy=1.16.2
-    - scikit-learn=0.20.1
+    - scipy
+    - numpy
+    - scikit-learn
   run:
     - python==3.6
     - pandas
-    - scipy=1.2.1
-    - numpy=1.16.2
-    - scikit-learn=0.20.1
+    - scipy
+    - numpy
+    - scikit-learn
 
 test:
   imports:

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,6 +1,6 @@
 python>=3.4
 pandas
-scipy=1.2.1
-numpy=1.16.2
-scikit-learn=0.20.1
+scipy
+numpy
+scikit-learn
 nose=1.3.7

--- a/factor_analyzer/confirmatory_factor_analyzer.py
+++ b/factor_analyzer/confirmatory_factor_analyzer.py
@@ -757,6 +757,7 @@ class ConfirmatoryFactorAnalyzer(BaseEstimator, TransformerMixin):
         self.aic_ = 2 * res.fun + 2 * (x0.shape[0] + self.model.n_variables)
         if self.n_obs is not None:
             self.bic_ = 2 * res.fun + np.log(self.n_obs) * (x0.shape[0] + self.model.n_variables)
+        return self
 
     def transform(self, X):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
-scipy==1.2.1
-numpy==1.16.2
-scikit-learn==0.20.1
+scipy
+numpy
+scikit-learn


### PR DESCRIPTION
This PR fixes a bug in the `fit()` method of CFA. This now returns `self`.
In addition, there are minor updates to the requirements files to make the installation more flexible.