### PR TITLE
Also re-order the structure matrix

### DIFF
--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -655,8 +655,9 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
         variance = self._get_factor_variance(loadings)[0]
         new_order = list(reversed(np.argsort(variance)))
         loadings = loadings[:, new_order].copy()
-        structure = structure[:, new_order].copy()
-
+        
+        if structure is not None: 
+            structure = structure[:, new_order].copy()
         
         self.phi_ = phi
         self.structure_ = structure

--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -653,8 +653,11 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
 
         # resort the factors according to their variance
         variance = self._get_factor_variance(loadings)[0]
-        loadings = loadings[:, list(reversed(np.argsort(variance)))].copy()
+        new_order = list(reversed(np.argsort(variance)))
+        loadings = loadings[:, new_order].copy()
+        structure = structure[:, new_order].copy()
 
+        
         self.phi_ = phi
         self.structure_ = structure
 


### PR DESCRIPTION
When an oblique rotation has changed the variance order of the factors, the factors are reordered to ensure the first has the greatest variance. However, the structure matrix was assigned using the loadings before reordering, which causes these orders to sometimes be different. 

This can cause a lot of surprise for the user; if the factors have been given interpretation, or names, a user may be stumped that the resulting factor scores do not match this interpretation at all, and correlate with different items than the ones with the strongest loadings. 

The proposed change is to also reorder the structure matrix, so that the factor scores are always in the same order as the factor loadings. This should theoretically solve the issue everywhere, but the package authors should be careful in whether this change has repercussions elsewhere. 

See also: 
https://stackoverflow.com/questions/59284044/factor-order-differs-between-loadings-and-scoring-with-oblimin-rotation-how-i