### PR TITLE
Add weights as attribute to factor_analyzer

### DIFF
--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -204,6 +204,10 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
         The factor correlations
         matrix. This only exists
         if the rotation is oblique.
+    weights : numpy array
+        The score coefficient component matrix.
+        Default to None, if `fit()` has not been
+        called.
 
     Notes
     -----
@@ -288,6 +292,7 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
         self.corr_ = None
         self.loadings_ = None
         self.rotation_matrix_ = None
+        self.weights_ = None
 
     @staticmethod
     def _fit_uls_objective(psi, corr_mtx, n_factors):
@@ -734,13 +739,13 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
             structure = self.loadings_
 
         try:
-            weights = np.linalg.solve(self.corr_, structure)
+            self.weights_ = np.linalg.solve(self.corr_, structure)
         except Exception as error:
             warnings.warn('Unable to calculate the factor score weights; '
                           'factor loadings used instead: {}'.format(error))
-            weights = self.loadings_
+            self.weights_  = self.loadings_
 
-        scores = np.dot(X_scale, weights)
+        scores = np.dot(X_scale, self.weights_ )
         return scores
 
     def get_eigenvalues(self):


### PR DESCRIPTION
Some applications require to access the score coefficient component matrix B . These coefficients are used to transform the standardized data into factors by computing F = Z · B, where Z are the standardized data and F the hidden factors.

An example of such use case can be found in the paper [Constructing an alternative dollar index to gauge the movements in currency markets](https://www.researchgate.net/publication/227440018_Constructing_an_alternative_dollar_index_to_gauge_the_movements_in_currency_markets).

In this paper, B is used to compute weights for the different indexes.

This pull request attempts to add an attribute to the class `factor_analyzer` to allow access to B (weights_).