### PR TITLE
corrected error meesage

### DIFF
--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -253,15 +253,15 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
 
         rotation = rotation.lower() if isinstance(rotation, str) else rotation
         if rotation not in POSSIBLE_ROTATIONS + [None]:
-            raise ValueError(f"The rotation must be None, or in the following set: {', '.join(POSSIBLE_ROTATIONS)}")
+            raise ValueError(f"The rotation must be one of the following: {POSSIBLE_ROTATIONS + [None]}")
 
         method = method.lower()
         if method not in POSSIBLE_METHODS:
-            raise ValueError(f"The method must be None, or in the following set: {', '.join(POSSIBLE_METHODS)}")
+            raise ValueError(f"The method must be one of the following: {POSSIBLE_METHODS + [None]}")
 
         impute = impute.lower()
         if impute not in POSSIBLE_IMPUTATIONS:
-            raise ValueError(f"The imputations must be None, or in the following set: {', '.join(POSSIBLE_IMPUTATIONS)}")
+            raise ValueError(f"The imputation must be one of the following: {POSSIBLE_IMPUTATIONS + [None]}")
 
         if method == 'principal' and is_corr_matrix:
             raise ValueError('The principal method is only implemented using '

--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -253,18 +253,18 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
 
         rotation = rotation.lower() if isinstance(rotation, str) else rotation
         if rotation not in POSSIBLE_ROTATIONS + [None]:
-            raise ValueError('The rotation must be None, or in the following set: '
-                             '\{{}\}'.format(', '.join(POSSIBLE_ROTATIONS)))
+            raise ValueError(f"The rotation must be None, or in the following set: 
+                             {', '.join(POSSIBLE_ROTATIONS)}")
 
         method = method.lower()
         if method not in POSSIBLE_METHODS:
-            raise ValueError('The method must be in the following set: '
-                             '\{{}\}'.format(', '.join(POSSIBLE_METHODS)))
+            raise ValueError(f"The method must be None, or in the following set: 
+                             {', '.join(POSSIBLE_METHODS)}")
 
         impute = impute.lower()
         if impute not in POSSIBLE_IMPUTATIONS:
-            raise ValueError('The imputation must be in the following set: '
-                             '\{{}\}'.format(', '.join(POSSIBLE_IMPUTATIONS)))
+            raise ValueError(f"The imputations must be None, or in the following set: 
+                             {', '.join(POSSIBLE_IMPUTATIONS)}")
 
         if method == 'principal' and is_corr_matrix:
             raise ValueError('The principal method is only implemented using '

--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -253,18 +253,15 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
 
         rotation = rotation.lower() if isinstance(rotation, str) else rotation
         if rotation not in POSSIBLE_ROTATIONS + [None]:
-            raise ValueError(f"The rotation must be None, or in the following set: 
-                             {', '.join(POSSIBLE_ROTATIONS)}")
+            raise ValueError(f"The rotation must be None, or in the following set: {', '.join(POSSIBLE_ROTATIONS)}")
 
         method = method.lower()
         if method not in POSSIBLE_METHODS:
-            raise ValueError(f"The method must be None, or in the following set: 
-                             {', '.join(POSSIBLE_METHODS)}")
+            raise ValueError(f"The method must be None, or in the following set: {', '.join(POSSIBLE_METHODS)}")
 
         impute = impute.lower()
         if impute not in POSSIBLE_IMPUTATIONS:
-            raise ValueError(f"The imputations must be None, or in the following set: 
-                             {', '.join(POSSIBLE_IMPUTATIONS)}")
+            raise ValueError(f"The imputations must be None, or in the following set: {', '.join(POSSIBLE_IMPUTATIONS)}")
 
         if method == 'principal' and is_corr_matrix:
             raise ValueError('The principal method is only implemented using '


### PR DESCRIPTION
Corrected error messages for unidentified rotation, method and imputation.
Currently they raise the following error due to a missing `}`:
```python
ValueError: Single '}' encountered in format string
```