### PR TITLE
Fix minor issue with signs in varimax rotation matrix

### DIFF
--- a/factor_analyzer/rotator.py
+++ b/factor_analyzer/rotator.py
@@ -503,9 +503,10 @@ class Rotator(BaseEstimator):
             # and rotation matrix
             basis = np.dot(X, rotation_mtx)
 
-            # transform data for singular value decomposition
-            transformed = np.dot(X.T, basis**3 - (1.0 / n_rows) *
-                                 np.dot(basis, np.diag(np.diag(np.dot(basis.T, basis)))))
+            # transform data for singular value decomposition using updated formula :
+            # B <- t(x) %*% (z^3 - z %*% diag(drop(rep(1, p) %*% z^2))/p)
+            diagonal = np.diag(np.squeeze(np.repeat(1, n_rows).dot(basis**2)))
+            transformed = X.T.dot(basis**3 - basis.dot(diagonal) / n_rows)
 
             # perform SVD on
             # the transformed matrix
@@ -516,7 +517,7 @@ class Rotator(BaseEstimator):
             d = np.sum(S)
 
             # check convergence
-            if old_d != 0 and d / old_d < 1 + self.tol:
+            if d < old_d * (1 + self.tol):
                 break
 
         # take inner product of loading matrix


### PR DESCRIPTION
With regard to issue #78, I have updated the varimax rotation a bit. There are a slightly different formulas for varimax, which can result in different signs in the rotation matrix, so this isn't exactly a bug. However, to be consistent with both SPSS and (most) implementations in R, I went with the implementation [here](https://github.com/nosbielcs/varimaxMethod/blob/master/varimax.R#L17).

This doesn't change the loading matrices at all, and none of the tests need to be updated. It should only impact the rotation matrix for certain edge cases. 

When it comes to the issue in question, R's `psych` library actually doesn't converge with the data set provided, using a varimax rotation. However, SPSS and `factor_anayzer` do converge, and now give the same result for the rotation matrix. (The values were always consistent; just some signs were different.)

@desilinguist , after this issue is merged, I think we're ready for a release. Sorry, it just took me a little bit of time to figure out what was going on, and I wanted to make sure this was resolved.