### PR TITLE
Fixing bug regarding unbound `new_order` variable

### DIFF
--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -548,10 +548,8 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
         # and the L-BFGS-B algorithm
         if self.method == 'ml' or self.method == 'mle':
             objective = self._fit_ml_objective
-        elif self.method == 'uls' or self.method == 'minres':
-            objective = self._fit_uls_objective
         else:
-            raise ValueError('The `objective` is not defined.')
+            objective = self._fit_uls_objective
 
         # use scipy to perform the actual minimization
         res = minimize(objective,
@@ -568,10 +566,8 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
         # and ml normalization for ML), and convert to DataFrame
         if self.method == 'ml' or self.method == 'mle':
             loadings = self._normalize_ml(res.x, corr_mtx, self. n_factors)
-        elif self.method == 'uls' or self.method == 'minres':
-            loadings = self._normalize_uls(res.x, corr_mtx, self.n_factors)
         else:
-            raise ValueError('The `method` is not defined.')
+            loadings = self._normalize_uls(res.x, corr_mtx, self.n_factors)
         return loadings
 
     def fit(self, X, y=None):

--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -550,6 +550,8 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
             objective = self._fit_ml_objective
         elif self.method == 'uls' or self.method == 'minres':
             objective = self._fit_uls_objective
+        else:
+            raise ValueError('The `objective` is not defined.')
 
         # use scipy to perform the actual minimization
         res = minimize(objective,
@@ -568,6 +570,8 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
             loadings = self._normalize_ml(res.x, corr_mtx, self. n_factors)
         elif self.method == 'uls' or self.method == 'minres':
             loadings = self._normalize_uls(res.x, corr_mtx, self.n_factors)
+        else:
+            raise ValueError('The `method` is not defined.')
         return loadings
 
     def fit(self, X, y=None):
@@ -688,9 +692,9 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
             new_order = list(reversed(np.argsort(variance)))
             loadings = loadings[:, new_order].copy()
 
-        # if the structure matrix exists, reorder
-        if structure is not None:
-            structure = structure[:, new_order].copy()
+            # if the structure matrix exists, reorder
+            if structure is not None:
+                structure = structure[:, new_order].copy()
 
         self.phi_ = phi
         self.structure_ = structure


### PR DESCRIPTION
This is simple bug fix. The `if structure is not None` statement should be nested under the preceding `if` statement, where `new_order` is defined. Since it's not, users can get an error if they're using the `principal` method with a rotation that creates a structure matrix.

This addresses issue #96.