### PR TITLE
Switch all tests to `nose2`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
     - /root/factordev/bin/curl -o /root/factordev/bin/codecov https://uploader.codecov.io/latest/linux/codecov
     - chmod +x /root/factordev/bin/codecov
   script:
-    - "/root/factordev/bin/nose2 -s ${TESTFILES}"
+    - "/root/factordev/bin/nose2 -s tests ${TESTFILES}"
     - "/root/factordev/bin/coverage xml"
   after_script:
     - /root/factordev/bin/codecov
@@ -25,12 +25,12 @@ variables:
 testset1:
   extends: ".runtests"
   variables:
-    TESTFILES: "tests/test_expected_confirmatory_factor_analyzer.py tests/test_factor_analyzer.py"
+    TESTFILES: "test_expected_confirmatory_factor_analyzer test_factor_analyzer"
   stage: "test"
 
 # second set of test files
 testset2:
   extends: ".runtests"
   variables:
-    TESTFILES: "tests/test_expected_factor_analyzer.py tests/test_expected_rotator.py tests/test_utils.py"
+    TESTFILES: "test_expected_factor_analyzer test_expected_rotator test_utils"
   stage: "test"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,21 +4,19 @@ stages:
   - test
 
 variables:
-  PYVERSION: "3.9"
-  NOSE_WITH_COV: "1"
-  NOSE_COVER_PACKAGE: "factor_analyzer"
+  PYVERSION: "3.11"
   LOGCAPTURE_LEVEL: "DEBUG"
   CODECOV_TOKEN: "034f0bb1-e590-406f-820c-4e7c41b17712"
 
 # set up the basic job
 .runtests:
   before_script:
-    - "conda create --prefix /root/factordev --channel conda-forge --file requirements.txt python=${PYVERSION} curl nose nose-cov --yes --quiet"
+    - "conda create --prefix /root/factordev --channel conda-forge --file requirements.txt python=${PYVERSION} curl nose2 coverage --yes --quiet"
     - /root/factordev/bin/pip install -e .
     - /root/factordev/bin/curl -o /root/factordev/bin/codecov https://uploader.codecov.io/latest/linux/codecov
     - chmod +x /root/factordev/bin/codecov
   script:
-    - "/root/factordev/bin/nosetests ${TESTFILES}"
+    - "/root/factordev/bin/nose2 -s ${TESTFILES}"
     - "/root/factordev/bin/coverage xml"
   after_script:
     - /root/factordev/bin/codecov

--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,13 @@ FactorAnalyzer
    :target: https://codecov.io/gh/EducationalTestingService/factor_analyzer
    :alt: Code coverage
 
-.. image:: https://anaconda.org/ets/factor_analyzer/badges/installer/conda.svg
+.. image:: https://anaconda.org/ets/factor_analyzer/badges/version.svg
    :target: https://anaconda.org/ets/factor_analyzer/
    :alt: Conda version
+
+.. image:: https://img.shields.io/pypi/v/factor_analyzer
+   :target: https://pypi.org/project/factor-analyzer/
+   :alt: PyPI version
 
 .. image:: https://img.shields.io/readthedocs/factor_analyzer/latest.svg
    :target: https://factor-analyzer.readthedocs.io/

--- a/tests/test_expected_confirmatory_factor_analyzer.py
+++ b/tests/test_expected_confirmatory_factor_analyzer.py
@@ -6,9 +6,10 @@ Tests for ``ConfirmatoryFactorAnalyzer`` class.
 :organization: Educational Testing Service
 :date: 2022-09-05
 """
+import unittest
+
 import numpy as np
 import pandas as pd
-from nose.tools import eq_, raises
 from numpy.testing import assert_array_equal
 
 from factor_analyzer.confirmatory_factor_analyzer import (
@@ -21,81 +22,69 @@ from factor_analyzer.test_utils import check_cfa
 THRESHOLD = 1.0
 
 
-def test_11_cfa():  # noqa: D103
+class TestConfirmatoryFactorAnalysis(unittest.TestCase):
+    def test_11_cfa(self):  # noqa: D103
+        json_name_input = "test11"
+        data_name_input = "test11"
 
-    json_name_input = "test11"
-    data_name_input = "test11"
+        for check in check_cfa(json_name_input, data_name_input, rel_tol=0.1):
+            self.assertGreaterEqual(check, THRESHOLD)
 
-    for check in check_cfa(json_name_input, data_name_input, rel_tol=0.1):
-        assert check >= THRESHOLD
+    def test_12_cfa(self):  # noqa: D103
+        json_name_input = "test12"
+        data_name_input = "test12"
 
+        for check in check_cfa(json_name_input, data_name_input, abs_tol=0.05):
+            self.assertGreaterEqual(check, THRESHOLD)
 
-def test_12_cfa():  # noqa: D103
+    def test_13_cfa(self):  # noqa: D103
+        json_name_input = "test13"
+        data_name_input = "test13"
 
-    json_name_input = "test12"
-    data_name_input = "test12"
+        for check in check_cfa(
+            json_name_input,
+            data_name_input,
+            index_col=0,
+            is_cov=True,
+            n_obs=64,
+            rel_tol=0.1,
+        ):
+            self.assertGreaterEqual(check, THRESHOLD)
 
-    for check in check_cfa(json_name_input, data_name_input, abs_tol=0.05):
-        assert check >= THRESHOLD
+    def test_14_cfa(self):  # noqa: D103
+        json_name_input = "test14"
+        data_name_input = "test14"
 
+        for check in check_cfa(
+            json_name_input, data_name_input, index_col=0, rel_tol=0.1
+        ):
+            self.assertGreaterEqual(check, THRESHOLD)
 
-def test_13_cfa():  # noqa: D103
+    def test_14_cfa_no_model(self):  # noqa: D103
+        X = np.array([[0, 0, 0, 0], [0, 0, 0, 0]])
 
-    json_name_input = "test13"
-    data_name_input = "test13"
+        with self.assertRaises(ValueError):
+            cfa = ConfirmatoryFactorAnalyzer("string_not_model")
+            cfa.fit(X)
 
-    for check in check_cfa(
-        json_name_input,
-        data_name_input,
-        index_col=0,
-        is_cov=True,
-        n_obs=64,
-        rel_tol=0.1,
-    ):
-        assert check >= THRESHOLD
+    def test_14_cfa_bad_bounds(self):  # noqa: D103
+        X = np.array([[0, 0, 0, 0], [0, 0, 0, 0]])
 
+        with self.assertRaises(AssertionError):
+            cfa = ConfirmatoryFactorAnalyzer(bounds=[(0, 1)])
+            cfa.fit(X)
 
-def test_14_cfa():  # noqa: D103
-
-    json_name_input = "test14"
-    data_name_input = "test14"
-
-    for check in check_cfa(json_name_input, data_name_input, index_col=0, rel_tol=0.1):
-        assert check >= THRESHOLD
-
-
-@raises(ValueError)
-def test_14_cfa_no_model():  # noqa: D103
-
-    X = np.array([[0, 0, 0, 0], [0, 0, 0, 0]])
-
-    cfa = ConfirmatoryFactorAnalyzer("string_not_model")
-    cfa.fit(X)
-
-
-@raises(AssertionError)
-def test_14_cfa_bad_bounds():  # noqa: D103
-
-    X = np.array([[0, 0, 0, 0], [0, 0, 0, 0]])
-
-    cfa = ConfirmatoryFactorAnalyzer(bounds=[(0, 1)])
-    cfa.fit(X)
+    def test_14_cfa_cov_with_no_obs(self):  # noqa: D103
+        with self.assertRaises(ValueError):
+            ConfirmatoryFactorAnalyzer(is_cov_matrix=True)
 
 
-@raises(ValueError)
-def test_14_cfa_cov_with_no_obs():  # noqa: D103
-
-    ConfirmatoryFactorAnalyzer(is_cov_matrix=True)
-
-
-class TestModelSpecificationParser:  # noqa: D101
+class TestModelSpecificationParser(unittest.TestCase):
     def test_model_spec_str(self):  # noqa: D102
-
         ms = ModelSpecification(np.array([[0, 0, 0]]), 3, 1)
-        assert str(ms).startswith("<ModelSpecification object at ")
+        self.assertTrue(str(ms).startswith("<ModelSpecification object at "))
 
     def test_model_spec_as_dict(self):  # noqa: D102
-
         loadings = np.array([[0, 0, 0]])
         n_factors = 3
         n_variables = 1
@@ -112,48 +101,52 @@ class TestModelSpecificationParser:  # noqa: D101
             if isinstance(value, np.ndarray):
                 assert_array_equal(new_dict[key], value)
             else:
-                eq_(new_dict[key], value)
+                self.assertEqual(new_dict[key], value)
 
     def test_model_spec_parser_from_dict_none(self):  # noqa: D102
         X = np.array([[0, 0, 0]])
         ms = ModelSpecificationParser.parse_model_specification_from_dict(X, None)
-        assert isinstance(ms, ModelSpecification)
-        eq_(ms.n_factors, 3)
-        eq_(ms.n_variables, 3)
+        self.assertTrue(isinstance(ms, ModelSpecification))
+        self.assertEqual(ms.n_factors, 3)
+        self.assertEqual(ms.n_variables, 3)
         assert_array_equal(ms.loadings, np.ones((3, 3), dtype=int))
 
-    @raises(ValueError)
     def test_model_spec_parser_from_dict_error(self):  # noqa: D102
         X = np.array([[0, 0, 0]])
-        ModelSpecificationParser.parse_model_specification_from_dict(X, "not_a_model")
+        with self.assertRaises(ValueError):
+            ModelSpecificationParser.parse_model_specification_from_dict(
+                X, "not_a_model"
+            )
 
     def test_model_spec_parser_from_array_none(self):  # noqa: D102
         X = np.array([[0, 0, 0]])
         ms = ModelSpecificationParser.parse_model_specification_from_array(X, None)
-        assert isinstance(ms, ModelSpecification)
-        eq_(ms.n_factors, 3)
-        eq_(ms.n_variables, 3)
+        self.assertTrue(isinstance(ms, ModelSpecification))
+        self.assertEqual(ms.n_factors, 3)
+        self.assertEqual(ms.n_variables, 3)
         assert_array_equal(ms.loadings, np.ones((3, 3), dtype=int))
 
     def test_model_spec_parser_from_array(self):  # noqa: D102
         X = np.array([[0, 0, 0]])
         spec = np.ones((3, 3), dtype=int)
         ms = ModelSpecificationParser.parse_model_specification_from_array(X, spec)
-        assert isinstance(ms, ModelSpecification)
-        eq_(ms.n_factors, 3)
-        eq_(ms.n_variables, 3)
+        self.assertTrue(isinstance(ms, ModelSpecification))
+        self.assertEqual(ms.n_factors, 3)
+        self.assertEqual(ms.n_variables, 3)
         assert_array_equal(ms.loadings, np.ones((3, 3), dtype=int))
 
     def test_model_spec_parser_from_frame(self):  # noqa: D102
         X = np.array([[0, 0, 0]])
         spec = pd.DataFrame(np.ones((3, 3), dtype=int))
         ms = ModelSpecificationParser.parse_model_specification_from_array(X, spec)
-        assert isinstance(ms, ModelSpecification)
-        eq_(ms.n_factors, 3)
-        eq_(ms.n_variables, 3)
+        self.assertTrue(isinstance(ms, ModelSpecification))
+        self.assertEqual(ms.n_factors, 3)
+        self.assertEqual(ms.n_variables, 3)
         assert_array_equal(ms.loadings, np.ones((3, 3), dtype=int))
 
-    @raises(ValueError)
     def test_model_spec_parser_from_array_error(self):  # noqa: D102
         X = np.array([[0, 0, 0]])
-        ModelSpecificationParser.parse_model_specification_from_array(X, "not_a_model")
+        with self.assertRaises(ValueError):
+            ModelSpecificationParser.parse_model_specification_from_array(
+                X, "not_a_model"
+            )

--- a/tests/test_expected_factor_analyzer.py
+++ b/tests/test_expected_factor_analyzer.py
@@ -7,6 +7,8 @@ Tests for expected factor analysis.
 :date: 2022-09-05
 """
 
+import unittest
+
 from factor_analyzer.test_utils import check_scenario
 
 # set a slightly lower threshold than just rotation
@@ -15,473 +17,411 @@ from factor_analyzer.test_utils import check_scenario
 THRESHOLD = 0.9
 
 
-def test_01_none_minres_3_factors_use_corr():  # noqa: D103
-
-    test_name = "test01"
-    factors = 3
-    method = "uls"
-    rotation = "none"
-
-    for check in check_scenario(
-        test_name, factors, method, rotation, use_corr_matrix=True
-    ):
-        assert check > THRESHOLD
-
-
-def test_01_none_minres_3_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 3
-    method = "uls"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_01_none_minres_2_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 2
-    method = "uls"
-    rotation = "none"
-
-    for check in check_scenario(
-        test_name, factors, method, rotation, check_scores=True
-    ):
-        assert check > THRESHOLD
-
-
-def test_01_varimax_minres_2_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 2
-    method = "uls"
-    rotation = "varimax"
-
-    for check in check_scenario(
-        test_name, factors, method, rotation, check_scores=True
-    ):
-        assert check > THRESHOLD
-
-
-def test_01_promax_minres_2_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 2
-    method = "uls"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-        check_structure=True,
-        check_scores=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_01_varimax_ml_3_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 3
-    method = "ml"
-    rotation = "varimax"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_01_promax_ml_3_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 3
-    method = "ml"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_01_promax_ml_3_factors_use_corr():  # noqa: D103
-
-    test_name = "test01"
-    factors = 3
-    method = "ml"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        use_corr_matrix=True,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_01_promax_uls_3_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 3
-    method = "uls"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_02_none_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_02_varimax_minres_2_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 2
-    method = "uls"
-    rotation = "varimax"
-
-    for check in check_scenario(
-        test_name, factors, method, rotation, check_scores=True
-    ):
-        assert check > THRESHOLD
-
-
-def test_02_promax_minres_2_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 2
-    method = "uls"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-        check_structure=True,
-        check_scores=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_03_none_minres_3_factors():  # noqa: D103
-
-    test_name = "test03"
-    factors = 3
-    method = "uls"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_03_promax_minres_3_factors():  # noqa: D103
-
-    test_name = "test03"
-    factors = 3
-    method = "uls"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_03_none_ml_2_factors():  # noqa: D103
-
-    test_name = "test03"
-    factors = 2
-    method = "ml"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_04_varimax_ml_2_factors():  # noqa: D103
-
-    test_name = "test04"
-    factors = 2
-    method = "ml"
-    rotation = "varimax"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_04_varimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test04"
-    factors = 3
-    method = "uls"
-    rotation = "varimax"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_05_varimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test05"
-    factors = 3
-    method = "uls"
-    rotation = "varimax"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_05_none_ml_2_factors():  # noqa: D103
-
-    test_name = "test05"
-    factors = 2
-    method = "ml"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_06_promax_ml_3_factors():  # noqa: D103
-
-    test_name = "test06"
-    factors = 3
-    method = "ml"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_06_none_minres_2_factors():  # noqa: D103
-
-    test_name = "test06"
-    factors = 2
-    method = "uls"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_07_varimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 3
-    method = "uls"
-    rotation = "varimax"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_07_varimax_ml_3_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 3
-    method = "ml"
-    rotation = "varimax"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_08_promax_ml_3_factors():  # noqa: D103
-
-    test_name = "test08"
-    factors = 3
-    method = "ml"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_08_none_ml_2_factors():  # noqa: D103
-
-    test_name = "test08"
-    factors = 2
-    method = "ml"
-    rotation = "none"
-
-    for check in check_scenario(test_name, factors, method, rotation):
-        assert check > THRESHOLD
-
-
-def test_09_promax_ml_3_factors():  # noqa: D103
-
-    test_name = "test09"
-    factors = 3
-    method = "ml"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_09_promax_minres_2_factors():  # noqa: D103
-
-    test_name = "test09"
-    factors = 2
-    method = "uls"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_10_none_ml_3_factors():  # noqa: D103
-
-    test_name = "test10"
-    factors = 3
-    method = "ml"
-    rotation = "none"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_10_varimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test10"
-    factors = 3
-    method = "uls"
-    rotation = "varimax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_10_promax_minres_3_factors():  # noqa: D103
-
-    test_name = "test10"
-    factors = 3
-    method = "uls"
-    rotation = "promax"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_02_none_principal():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "principal"
-    rotation = "none"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
-
-
-def test_15_none_principal():  # noqa: D103
-
-    test_name = "test15"
-    factors = 20
-    method = "principal"
-    rotation = "none"
-    svd_method = "lapack"
-
-    for check in check_scenario(
-        test_name,
-        factors,
-        method,
-        rotation,
-        svd_method=svd_method,
-        ignore_value=True,
-        ignore_communalities=True,
-    ):
-        assert check > THRESHOLD
+class TestExpectedFactorAnalysis(unittest.TestCase):
+    def test_01_none_minres_3_factors_use_corr(self):  # noqa: D103
+        test_name = "test01"
+        factors = 3
+        method = "uls"
+        rotation = "none"
+
+        for check in check_scenario(
+            test_name, factors, method, rotation, use_corr_matrix=True
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_none_minres_3_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 3
+        method = "uls"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_none_minres_2_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 2
+        method = "uls"
+        rotation = "none"
+
+        for check in check_scenario(
+            test_name, factors, method, rotation, check_scores=True
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_varimax_minres_2_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 2
+        method = "uls"
+        rotation = "varimax"
+
+        for check in check_scenario(
+            test_name, factors, method, rotation, check_scores=True
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_promax_minres_2_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 2
+        method = "uls"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+            check_structure=True,
+            check_scores=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_varimax_ml_3_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 3
+        method = "ml"
+        rotation = "varimax"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_promax_ml_3_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 3
+        method = "ml"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_promax_ml_3_factors_use_corr(self):  # noqa: D103
+        test_name = "test01"
+        factors = 3
+        method = "ml"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            use_corr_matrix=True,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_01_promax_uls_3_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 3
+        method = "uls"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_02_none_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_02_varimax_minres_2_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 2
+        method = "uls"
+        rotation = "varimax"
+
+        for check in check_scenario(
+            test_name, factors, method, rotation, check_scores=True
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_02_promax_minres_2_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 2
+        method = "uls"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+            check_structure=True,
+            check_scores=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_03_none_minres_3_factors(self):  # noqa: D103
+        test_name = "test03"
+        factors = 3
+        method = "uls"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_03_promax_minres_3_factors(self):  # noqa: D103
+        test_name = "test03"
+        factors = 3
+        method = "uls"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_03_none_ml_2_factors(self):  # noqa: D103
+        test_name = "test03"
+        factors = 2
+        method = "ml"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_04_varimax_ml_2_factors(self):  # noqa: D103
+        test_name = "test04"
+        factors = 2
+        method = "ml"
+        rotation = "varimax"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_04_varimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test04"
+        factors = 3
+        method = "uls"
+        rotation = "varimax"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_05_varimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test05"
+        factors = 3
+        method = "uls"
+        rotation = "varimax"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_05_none_ml_2_factors(self):  # noqa: D103
+        test_name = "test05"
+        factors = 2
+        method = "ml"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_06_promax_ml_3_factors(self):  # noqa: D103
+        test_name = "test06"
+        factors = 3
+        method = "ml"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_06_none_minres_2_factors(self):  # noqa: D103
+        test_name = "test06"
+        factors = 2
+        method = "uls"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_07_varimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 3
+        method = "uls"
+        rotation = "varimax"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_07_varimax_ml_3_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 3
+        method = "ml"
+        rotation = "varimax"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_08_promax_ml_3_factors(self):  # noqa: D103
+        test_name = "test08"
+        factors = 3
+        method = "ml"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_08_none_ml_2_factors(self):  # noqa: D103
+        test_name = "test08"
+        factors = 2
+        method = "ml"
+        rotation = "none"
+
+        for check in check_scenario(test_name, factors, method, rotation):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_09_promax_ml_3_factors(self):  # noqa: D103
+        test_name = "test09"
+        factors = 3
+        method = "ml"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_09_promax_minres_2_factors(self):  # noqa: D103
+        test_name = "test09"
+        factors = 2
+        method = "uls"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_10_none_ml_3_factors(self):  # noqa: D103
+        test_name = "test10"
+        factors = 3
+        method = "ml"
+        rotation = "none"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_10_varimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test10"
+        factors = 3
+        method = "uls"
+        rotation = "varimax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_10_promax_minres_3_factors(self):  # noqa: D103
+        test_name = "test10"
+        factors = 3
+        method = "uls"
+        rotation = "promax"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_02_none_principal(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "principal"
+        rotation = "none"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)
+
+    def test_15_none_principal(self):  # noqa: D103
+        test_name = "test15"
+        factors = 20
+        method = "principal"
+        rotation = "none"
+        svd_method = "lapack"
+
+        for check in check_scenario(
+            test_name,
+            factors,
+            method,
+            rotation,
+            svd_method=svd_method,
+            ignore_value=True,
+            ignore_communalities=True,
+        ):
+            self.assertGreater(check, THRESHOLD)

--- a/tests/test_expected_rotator.py
+++ b/tests/test_expected_rotator.py
@@ -6,250 +6,210 @@
 :date: 2022-09-05
 """
 
+import unittest
+
 from factor_analyzer.test_utils import check_rotation
 
 # set a threshold of roughly 95 percent matching
 THRESHOLD = 0.95
 
 
-def test_01_varimax_minres_2_factors():  # noqa: D103
-
-    test_name = "test01"
-    factors = 2
-    method = "uls"
-    rotation = "varimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_02_varimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "varimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_02_oblimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "oblimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_02_oblimin_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "oblimin"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_02_quartimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "quartimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_02_quartimin_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "quartimin"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_04_oblimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test04"
-    factors = 3
-    method = "uls"
-    rotation = "oblimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_04_oblimin_minres_3_factors():  # noqa: D103
-
-    test_name = "test04"
-    factors = 3
-    method = "uls"
-    rotation = "oblimin"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_04_quartimax_minres_3_factors():  # noqa: D103
-
-    test_name = "test04"
-    factors = 3
-    method = "uls"
-    rotation = "quartimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_04_quartimin_minres_3_factors():  # noqa: D103
-
-    test_name = "test04"
-    factors = 3
-    method = "uls"
-    rotation = "quartimin"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_07_oblimax_minres_2_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 2
-    method = "uls"
-    rotation = "oblimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_07_oblimin_minres_3_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 2
-    method = "uls"
-    rotation = "oblimin"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_07_quartimax_minres_2_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 2
-    method = "uls"
-    rotation = "quartimax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_07_quartimin_minres_2_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 2
-    method = "uls"
-    rotation = "quartimin"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_07_equamax_minres_2_factors():  # noqa: D103
-
-    test_name = "test07"
-    factors = 2
-    method = "uls"
-    rotation = "equamax"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check > THRESHOLD
-
-
-def test_07_oblimin_minres_2_factors_gamma():  # noqa: D103
-
-    test_name = "test07_gamma"
-    factors = 2
-    method = "uls"
-    rotation = "oblimin"
-    gamma = 0.5
-
-    check = check_rotation(test_name, factors, method, rotation, gamma=gamma)
-    assert check > THRESHOLD
-
-
-def test_02_geomin_obl_minres_2_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 2
-    method = "uls"
-    rotation = "geomin_obl"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check == 1
-
-
-def test_02_geomin_obl_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "geomin_obl"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check == 1
-
-
-def test_02_geomin_obl_ml_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "ml"
-    rotation = "geomin_obl"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check == 1
-
-
-def test_02_geomin_ort_minres_2_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 2
-    method = "uls"
-    rotation = "geomin_ort"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check == 1
-
-
-def test_02_geomin_ort_minres_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "uls"
-    rotation = "geomin_ort"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check == 1
-
-
-def test_02_geomin_ort_ml_3_factors():  # noqa: D103
-
-    test_name = "test02"
-    factors = 3
-    method = "ml"
-    rotation = "geomin_ort"
-
-    check = check_rotation(test_name, factors, method, rotation)
-    assert check == 1
+class TestRotator(unittest.TestCase):
+    def test_01_varimax_minres_2_factors(self):  # noqa: D103
+        test_name = "test01"
+        factors = 2
+        method = "uls"
+        rotation = "varimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_02_varimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "varimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_02_oblimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "oblimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_02_oblimin_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "oblimin"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_02_quartimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "quartimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_02_quartimin_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "quartimin"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_04_oblimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test04"
+        factors = 3
+        method = "uls"
+        rotation = "oblimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_04_oblimin_minres_3_factors(self):  # noqa: D103
+        test_name = "test04"
+        factors = 3
+        method = "uls"
+        rotation = "oblimin"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_04_quartimax_minres_3_factors(self):  # noqa: D103
+        test_name = "test04"
+        factors = 3
+        method = "uls"
+        rotation = "quartimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_04_quartimin_minres_3_factors(self):  # noqa: D103
+        test_name = "test04"
+        factors = 3
+        method = "uls"
+        rotation = "quartimin"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_07_oblimax_minres_2_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 2
+        method = "uls"
+        rotation = "oblimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_07_oblimin_minres_3_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 2
+        method = "uls"
+        rotation = "oblimin"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_07_quartimax_minres_2_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 2
+        method = "uls"
+        rotation = "quartimax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_07_quartimin_minres_2_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 2
+        method = "uls"
+        rotation = "quartimin"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_07_equamax_minres_2_factors(self):  # noqa: D103
+        test_name = "test07"
+        factors = 2
+        method = "uls"
+        rotation = "equamax"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_07_oblimin_minres_2_factors_gamma(self):  # noqa: D103
+        test_name = "test07_gamma"
+        factors = 2
+        method = "uls"
+        rotation = "oblimin"
+        gamma = 0.5
+
+        check = check_rotation(test_name, factors, method, rotation, gamma=gamma)
+        self.assertGreater(check, THRESHOLD)
+
+    def test_02_geomin_obl_minres_2_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 2
+        method = "uls"
+        rotation = "geomin_obl"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertEqual(check, 1)
+
+    def test_02_geomin_obl_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "geomin_obl"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertEqual(check, 1)
+
+    def test_02_geomin_obl_ml_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "ml"
+        rotation = "geomin_obl"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertEqual(check, 1)
+
+    def test_02_geomin_ort_minres_2_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 2
+        method = "uls"
+        rotation = "geomin_ort"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertEqual(check, 1)
+
+    def test_02_geomin_ort_minres_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "uls"
+        rotation = "geomin_ort"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertEqual(check, 1)
+
+    def test_02_geomin_ort_ml_3_factors(self):  # noqa: D103
+        test_name = "test02"
+        factors = 3
+        method = "ml"
+        rotation = "geomin_ort"
+
+        check = check_rotation(test_name, factors, method, rotation)
+        self.assertEqual(check, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,10 +7,11 @@ Tests utilities.
 :date: 2022-09-05
 """
 
+import unittest
+
 import numpy as np
 import pandas as pd
-from nose.tools import eq_, raises
-from numpy.testing import assert_array_equal, assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 
 from factor_analyzer.utils import (
     commutation_matrix,
@@ -28,216 +29,183 @@ from factor_analyzer.utils import (
 )
 
 
-def test_unique_elements():  # noqa: D103
+class TestUtils(unittest.TestCase):
+    def test_unique_elements(self):  # noqa: D103
+        expected = [1, 2, 3, 4, 5]
 
-    expected = [1, 2, 3, 4, 5]
+        x = [1, 2, 3, 2, 1, 3, 4, 4, 3, 5, 5]
+        output = unique_elements(x)
+        self.assertEqual(output, expected)
 
-    x = [1, 2, 3, 2, 1, 3, 4, 4, 3, 5, 5]
-    output = unique_elements(x)
-    eq_(output, expected)
+    def test_fill_lower_diag(self):  # noqa: D103
+        expected = np.array([[0, 0, 0], [1, 0, 0], [2, 3, 0]])
+        output = fill_lower_diag([1, 2, 3])
+        assert_array_equal(output, expected)
 
+    def test_merge_variance_covariance_no_covariance(self):  # noqa: D103
+        expected = np.eye(4)
 
-def test_fill_lower_diag():  # noqa: D103
+        x = np.array([1, 1, 1, 1])
 
-    expected = np.array([[0, 0, 0], [1, 0, 0], [2, 3, 0]])
-    output = fill_lower_diag([1, 2, 3])
-    assert_array_equal(output, expected)
+        output = merge_variance_covariance(x)
+        assert_array_equal(output, expected)
 
+    def test_merge_variance_covariance(self):  # noqa: D103
+        expected = [[1, 0.25, 0.45], [0.25, 1, 0.35], [0.45, 0.35, 1]]
+        expected = np.array(expected)
 
-def test_merge_variance_covariance_no_covariance():  # noqa: D103
+        x = np.array([1, 1, 1])
+        y = np.array([0.25, 0.45, 0.35])
 
-    expected = np.eye(4)
+        output = merge_variance_covariance(x, y)
+        assert_array_equal(output, expected)
 
-    x = np.array([1, 1, 1, 1])
+    def test_get_first_idxs_from_values(self):  # noqa: D103
+        expected = [2, 0, 1], [0, 1, 2]
+        x = np.array([[np.nan, 1, np.nan], [np.nan, 1, 1], [1, 2, np.nan], [1, 1, 1]])
+        output = get_first_idxs_from_values(x)
 
-    output = merge_variance_covariance(x)
-    assert_array_equal(output, expected)
+        self.assertEqual(output, expected)
 
+    def test_get_free_parameter_idxs(self):  # noqa: D103
+        x = np.array([[np.nan, np.nan, 1], [1, np.nan, 1], [1, 1, np.nan]])
 
-def test_merge_variance_covariance():  # noqa: D103
+        expected = np.array([0, 3, 4, 8])
 
-    expected = [[1, 0.25, 0.45], [0.25, 1, 0.35], [0.45, 0.35, 1]]
-    expected = np.array(expected)
+        output = get_free_parameter_idxs(x, eq=-1)
+        assert_array_equal(output, expected)
 
-    x = np.array([1, 1, 1])
-    y = np.array([0.25, 0.45, 0.35])
+    def test_duplication_matrix(self):  # noqa: D103
+        output = duplication_matrix(3)
 
-    output = merge_variance_covariance(x, y)
-    assert_array_equal(output, expected)
+        expected = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            ]
+        )
 
+        assert_array_equal(output, expected)
 
-def test_get_first_idxs_from_values():  # noqa: D103
-    expected = [2, 0, 1], [0, 1, 2]
-    x = np.array([[np.nan, 1, np.nan], [np.nan, 1, 1], [1, 2, np.nan], [1, 1, 1]])
-    output = get_first_idxs_from_values(x)
+    def test_duplication_matrix_pre_post(self):  # noqa: D103
+        x = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
 
-    eq_(output, expected)
+        expected = np.array([[1, 5, 4], [14, 34, 20], [13, 29, 16]])
+        expected = pd.DataFrame(expected)
 
+        output = duplication_matrix_pre_post(x)
 
-def test_get_free_parameter_idxs():  # noqa: D103
+        assert_array_equal(output, expected.values)
 
-    x = np.array([[np.nan, np.nan, 1], [1, np.nan, 1], [1, 1, np.nan]])
+    def test_commutation_matrix(self):  # noqa: D103
+        expected = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
 
-    expected = np.array([0, 3, 4, 8])
+        output = commutation_matrix(2, 2)
 
-    output = get_free_parameter_idxs(x, eq=-1)
-    assert_array_equal(output, expected)
+        assert_array_equal(output, expected)
 
+    def test_get_symmetric_lower_idxs(self):  # noqa: D103
+        expected = np.array([0, 1, 2, 3, 4, 6, 7, 8, 9, 12, 13, 14, 18, 19, 24])
 
-def test_duplication_matrix():  # noqa: D103
+        output = get_symmetric_lower_idxs(5)
 
-    output = duplication_matrix(3)
+        assert_array_equal(output, expected)
 
-    expected = np.array(
-        [
-            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+    def test_get_symmetric_lower_idxs_no_diag(self):  # noqa: D103
+        expected = np.array([5, 10, 11, 15, 16, 17, 20, 21, 22, 23])
+
+        output = get_symmetric_lower_idxs(5, diag=False)
+
+        assert_array_equal(output, expected)
+
+    def test_get_symmetric_upper_idxs(self):  # noqa: D103
+        expected = np.array([0, 5, 10, 15, 20, 6, 11, 16, 21, 12, 17, 22, 18, 23, 24])
+
+        output = get_symmetric_upper_idxs(5)
+
+        assert_array_equal(output, expected)
+
+    def test_get_symmetric_upper_idxs_no_diag(self):  # noqa: D103
+        expected = np.array([1, 2, 7, 3, 8, 13, 4, 9, 14, 19])
+
+        output = get_symmetric_upper_idxs(5, diag=False)
+
+        assert_array_equal(output, expected)
+
+    def test_covariance_to_correlation(self):  # noqa: D103
+        path = "tests/data/test02.csv"
+        data = pd.read_csv(path)
+
+        expected_corr = data.corr().values
+
+        corr = covariance_to_correlation(data.cov().values)
+
+        assert_almost_equal(corr, expected_corr)
+
+    def test_covariance_to_correlation_value_error(self):  # noqa: D103
+        with self.assertRaises(ValueError):
+            covariance_to_correlation(np.array([[23, 12, 23], [42, 25, 21]]))
+
+    def test_partial_correlations(self):  # noqa: D103
+        data = pd.DataFrame([[12, 14, 15], [24, 12, 52], [35, 12, 41], [23, 12, 42]])
+
+        expected = [
+            [1.0, -0.7309547, -0.50616],
+            [-0.7309547, 1.0, -0.9287013],
+            [-0.50616, -0.9287013, 1.0],
         ]
-    )
 
-    assert_array_equal(output, expected)
+        expected = pd.DataFrame(expected, columns=[0, 1, 2], index=[0, 1, 2])
 
+        result = partial_correlations(data)
+        assert_almost_equal(result, expected.values)
 
-def test_duplication_matrix_pre_post():  # noqa: D103
+    def test_partial_correlations_num_columns_greater(self):  # noqa: D103
+        # columns greater than rows
+        data = pd.DataFrame([[23, 12, 23], [42, 25, 21]])
 
-    x = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
+        empty_array = np.empty((3, 3))
+        empty_array[:] = np.nan
+        np.fill_diagonal(empty_array, 1.0)
 
-    expected = np.array([[1, 5, 4], [14, 34, 20], [13, 29, 16]])
-    expected = pd.DataFrame(expected)
+        expected = pd.DataFrame(empty_array, columns=[0, 1, 2], index=[0, 1, 2])
 
-    output = duplication_matrix_pre_post(x)
+        result = partial_correlations(data)
+        assert_almost_equal(result, expected.values)
 
-    assert_array_equal(output, expected.values)
+    def test_partial_correlations_with_zero_det(self):  # noqa: D103
+        # Covariance matrix that will be singular
+        data = pd.DataFrame(
+            [
+                [10, 10, 10, 10],
+                [12, 12, 12, 12],
+                [15, 15, 15, 15],
+                [20, 20, 20, 20],
+                [11, 11, 11, 11],
+            ]
+        )
 
-
-def test_commutation_matrix():  # noqa: D103
-
-    expected = np.array(
-        [
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0],
+        expected = [
+            [1.0, -0.9999999999999998, -0.9999999999999998, -0.9999999999999998],
+            [-1.0000000000000004, 1.0, -1.0, -1.0],
+            [-1.0000000000000004, -1.0, 1.0, -1.0],
+            [-1.0000000000000004, -1.0, -1.0, 1.0],
         ]
-    )
+        expected = pd.DataFrame(expected)
 
-    output = commutation_matrix(2, 2)
-
-    assert_array_equal(output, expected)
-
-
-def test_get_symmetric_lower_idxs():  # noqa: D103
-
-    expected = np.array([0, 1, 2, 3, 4, 6, 7, 8, 9, 12, 13, 14, 18, 19, 24])
-
-    output = get_symmetric_lower_idxs(5)
-
-    assert_array_equal(output, expected)
-
-
-def test_get_symmetric_lower_idxs_no_diag():  # noqa: D103
-
-    expected = np.array([5, 10, 11, 15, 16, 17, 20, 21, 22, 23])
-
-    output = get_symmetric_lower_idxs(5, diag=False)
-
-    assert_array_equal(output, expected)
-
-
-def test_get_symmetric_upper_idxs():  # noqa: D103
-
-    expected = np.array([0, 5, 10, 15, 20, 6, 11, 16, 21, 12, 17, 22, 18, 23, 24])
-
-    output = get_symmetric_upper_idxs(5)
-
-    assert_array_equal(output, expected)
-
-
-def test_get_symmetric_upper_idxs_no_diag():  # noqa: D103
-
-    expected = np.array([1, 2, 7, 3, 8, 13, 4, 9, 14, 19])
-
-    output = get_symmetric_upper_idxs(5, diag=False)
-
-    assert_array_equal(output, expected)
-
-
-def test_covariance_to_correlation():  # noqa: D103
-
-    path = "tests/data/test02.csv"
-    data = pd.read_csv(path)
-
-    expected_corr = data.corr().values
-
-    corr = covariance_to_correlation(data.cov().values)
-
-    assert_almost_equal(corr, expected_corr)
-
-
-@raises(ValueError)
-def test_covariance_to_correlation_value_error():  # noqa: D103
-
-    covariance_to_correlation(np.array([[23, 12, 23], [42, 25, 21]]))
-
-
-def test_partial_correlations():  # noqa: D103
-
-    data = pd.DataFrame([[12, 14, 15], [24, 12, 52], [35, 12, 41], [23, 12, 42]])
-
-    expected = [
-        [1.0, -0.7309547, -0.50616],
-        [-0.7309547, 1.0, -0.9287013],
-        [-0.50616, -0.9287013, 1.0],
-    ]
-
-    expected = pd.DataFrame(expected, columns=[0, 1, 2], index=[0, 1, 2])
-
-    result = partial_correlations(data)
-    assert_almost_equal(result, expected.values)
-
-
-def test_partial_correlations_num_columns_greater():  # noqa: D103
-
-    # columns greater than rows
-    data = pd.DataFrame([[23, 12, 23], [42, 25, 21]])
-
-    empty_array = np.empty((3, 3))
-    empty_array[:] = np.nan
-    np.fill_diagonal(empty_array, 1.0)
-
-    expected = pd.DataFrame(empty_array, columns=[0, 1, 2], index=[0, 1, 2])
-
-    result = partial_correlations(data)
-    assert_almost_equal(result, expected.values)
-
-
-def test_partial_correlations_with_zero_det():  # noqa: D103
-
-    # Covariance matrix that will be singular
-    data = pd.DataFrame(
-        [
-            [10, 10, 10, 10],
-            [12, 12, 12, 12],
-            [15, 15, 15, 15],
-            [20, 20, 20, 20],
-            [11, 11, 11, 11],
-        ]
-    )
-
-    expected = [
-        [1.0, -0.9999999999999998, -0.9999999999999998, -0.9999999999999998],
-        [-1.0000000000000004, 1.0, -1.0, -1.0],
-        [-1.0000000000000004, -1.0, 1.0, -1.0],
-        [-1.0000000000000004, -1.0, -1.0, 1.0],
-    ]
-    expected = pd.DataFrame(expected)
-
-    result = partial_correlations(data)
-    assert_almost_equal(result, expected.values)
+        result = partial_correlations(data)
+        assert_almost_equal(result, expected.values)

--- a/unittest.cfg
+++ b/unittest.cfg
@@ -1,0 +1,11 @@
+[unittest]
+plugins = nose2.plugins.junitxml
+
+[junit-xml]
+always-on = True
+path = junit.xml
+
+[coverage]
+always-on = True
+source = factor_analyzer
+xml-report = True


### PR DESCRIPTION
- Convert all test files to be nose2-compatible.
- Add nose2 configuration file.
- Update Gitlab CI file.
  - Use Python 3.11 instead of Python 3.9.
  - Use nose2 for testing instead of nose.
- Update README.rst.
  - Add PyPI badge.
  - Fix conda badge.
