### PR TITLE
Pre commit to dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ in the repository if you would like to contribute.
 
 You can install the development requirements in a virtual environment with:
 
-.. codeblock::
+.. code-block:: bash
 
    python -m pip install -e .[dev]
    pre-commit install

--- a/README.rst
+++ b/README.rst
@@ -202,13 +202,19 @@ Requirements
 -  ``pandas``
 -  ``scipy``
 -  ``scikit-learn``
--  ``pre-commit``
 
 Contributing
 ------------
 
 Contributions to ``factor_analyzer`` are very welcome. Please file an issue
 in the repository if you would like to contribute.
+
+You can install the development requirements in a virtual environment with:
+
+.. codeblock::
+
+   python -m pip install -e .[dev]
+   pre-commit install
 
 Installation
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = [
+  "setuptools >= 59.0.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 profile = "black"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pandas
 scipy
 numpy
 scikit-learn
-pre-commit

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     maintainer_email="nmadnani@ets.org",
     url="https://github.com/EducationalTestingService/factor_analyzer",
     install_requires=requirements(),
+    extras_require={"dev": ["pre-commit"]},
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Move pre-commit to a development extra and update the docs to show how to install the dev deps for a contributor.

I also added a basic build section to the `pyproject.toml` so that pip can identify what build system the project is using if installing locally. In [python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#ensurepip), it may not be safe to assume setuptools is always installed in every environment.

Some more info on the pyproject:
* https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement
* https://peps.python.org/pep-0517/

Fixes https://github.com/EducationalTestingService/factor_analyzer/issues/129