### PR TITLE
Pre commit to dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ in the repository if you would like to contribute.
 
 You can install the development requirements in a virtual environment with:
 
-.. codeblock::
+.. code-block:: bash
 
    python -m pip install -e .[dev]
    pre-commit install

--- a/README.rst
+++ b/README.rst
@@ -202,13 +202,19 @@ Requirements
 -  ``pandas``
 -  ``scipy``
 -  ``scikit-learn``
--  ``pre-commit``
 
 Contributing
 ------------
 
 Contributions to ``factor_analyzer`` are very welcome. Please file an issue
 in the repository if you would like to contribute.
+
+You can install the development requirements in a virtual environment with:
+
+.. codeblock::
+
+   python -m pip install -e .[dev]
+   pre-commit install
 
 Installation
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = [
+  "setuptools >= 59.0.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 profile = "black"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pandas
 scipy
 numpy
 scikit-learn
-pre-commit

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     maintainer_email="nmadnani@ets.org",
     url="https://github.com/EducationalTestingService/factor_analyzer",
     install_requires=requirements(),
+    extras_require={"dev": ["pre-commit"]},
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Submitting from in the org as a continuation of #130 

Fixes https://github.com/EducationalTestingService/factor_analyzer/issues/129

Just tested the install on python 3.12 and that is functioning. Also unit tests passed. There were some failures with pre-commit on unrelated files. I left those out for now but happy to fix them up.

Steps:

<details>

```shell
virtualenv py312 --py 3.12
. py312/bin/activate
python -m pip install -e .[dev]

python --version 
Python 3.12.0

python -m unittest discover ./tests/   
Ran 101 tests in 18.545s

OK

pre-commit run --all-files 
...
trim trailing whitespace.................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing tests/sufficiency_test.r

check for added large files..............................................Passed
check python ast.........................................................Passed
check json...............................................................Passed
debug statements (python)................................................Passed
check for merge conflicts................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

factor_analyzer/factor_analyzer.py:998:102: E501 line too long (109 > 101 characters)

isort....................................................................Passed
flynt....................................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted factor_analyzer\test_utils.py
reformatted factor_analyzer\rotator.py

All done! ✨ 🍰 ✨
2 files reformatted, 11 files left unchanged.

pydocstyle...............................................................Passed
```

</details>