### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,11 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - requirements: doc/requirements.txt
+
 build:
   os: "ubuntu-22.04"
   tools:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -218,6 +218,6 @@ epub_exclude_files = ["search.html"]
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/": None,
-    "https://numpy.org/doc/stable/": None,
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
 }

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+pandas
+scikit-learn
+scipy
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
- Add readthedocs yaml configuration file.
- Fix intersphinx mappings format in `doc/conf.py`.
- Add `doc/requirements.txt` and update readthedocs config to use requirements.

Here's the docs compiled from this branch: https://factor-analyzer.readthedocs.io/en/fix-readthedocs-build/