### PR TITLE
fix: updated deprecated scikit-learn parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ Requirements
 -  ``numpy``
 -  ``pandas``
 -  ``scipy``
--  ``scikit-learn``
+-  ``scikit-learn >= 1.6.0``
 
 Contributing
 ------------

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -79,7 +79,7 @@ Requirements
 -  ``numpy``
 -  ``pandas``
 -  ``scipy``
--  ``scikit-learn``
+-  ``scikit-learn >= 1.6.0``
 -  ``pre-commit``
 
 Installation

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 pandas
-scikit-learn
+scikit-learn >= 1.6.0
 scipy
 sphinx
 sphinx_rtd_theme

--- a/factor_analyzer/confirmatory_factor_analyzer.py
+++ b/factor_analyzer/confirmatory_factor_analyzer.py
@@ -681,7 +681,7 @@ class ConfirmatoryFactorAnalyzer(BaseEstimator, TransformerMixin):
 
         # now check the array, and make sure it
         # meets all of our expected criteria
-        X = check_array(X, force_all_finite="allow-nan", estimator=self, copy=True)
+        X = check_array(X, ensure_all_finite="allow-nan", estimator=self, copy=True)
 
         # check to see if there are any null values, and if
         # so impute using the desired imputation approach
@@ -824,7 +824,7 @@ class ConfirmatoryFactorAnalyzer(BaseEstimator, TransformerMixin):
 
         # now check the array, and make sure it
         # meets all of our expected criteria
-        X = check_array(X, force_all_finite=True, estimator=self, copy=True)
+        X = check_array(X, ensure_all_finite=True, estimator=self, copy=True)
 
         # meets all of our expected criteria
         check_is_fitted(self, ["loadings_", "error_vars_"])

--- a/factor_analyzer/factor_analyzer.py
+++ b/factor_analyzer/factor_analyzer.py
@@ -627,7 +627,7 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
 
         # now check the array, and make sure it
         # meets all of our expected criteria
-        X = check_array(X, force_all_finite="allow-nan", estimator=self, copy=True)
+        X = check_array(X, ensure_all_finite="allow-nan", estimator=self, copy=True)
 
         # check to see if there are any null values, and if
         # so impute using the desired imputation approach
@@ -756,7 +756,7 @@ class FactorAnalyzer(BaseEstimator, TransformerMixin):
 
         # now check the array, and make sure it
         # meets all of our expected criteria
-        X = check_array(X, force_all_finite=True, estimator=self, copy=True)
+        X = check_array(X, ensure_all_finite=True, estimator=self, copy=True)
 
         # meets all of our expected criteria
         check_is_fitted(self, "loadings_")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 scipy
 numpy
-scikit-learn
+scikit-learn >= 1.6.0


### PR DESCRIPTION
- scikit-learn  API Change: assert_all_finite parameter of functions utils.check_array, utils.check_X_y, utils.as_float_array is renamed into ensure_all_finite.
-  requires scikit-learn >=1.6

closes #138 