### PR TITLE
Run compatibility tests with multiple python environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.pyo
 *.egg
 *.egg-info/
+*.tox
+**/.python-version
 
 .DS_Store
 .coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,15 @@ stages:
   - test
 
 variables:
-  PYVERSION: "3.11"
+  PYVERSION: ""
   LOGCAPTURE_LEVEL: "DEBUG"
   CODECOV_TOKEN: "034f0bb1-e590-406f-820c-4e7c41b17712"
 
 # set up the basic job
 .runtests:
+  parallel:
+    matrix:
+      - PYVERSION: ["3.9", "3.10", "3.11", "3.12", "3.13"]
   before_script:
     - "conda create --prefix /root/factordev --channel conda-forge --file requirements.txt python=${PYVERSION} curl nose2 coverage --yes --quiet"
     - /root/factordev/bin/pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 scipy
 numpy
 scikit-learn >= 1.6.0
+tox >= 4

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     zip_safe=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+env_list = py39, py310, py311, py312, py313
+
+[testenv]
+deps =
+    pytest
+    -r requirements.txt
+commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-env_list = py39, py310, py311, py312, py313
+env_list = lint, 3.9, 3.1{0, 1, 2, 3}
 
 [testenv]
 deps =
     pytest
     -r requirements.txt
-commands = pytest
+commands = pytest -W ignore::UserWarning -W ignore::DeprecationWarning
+
+[testenv:lint]
+description = run linters
+skip_install = true
+deps =
+    black
+commands = black {posargs:.}


### PR DESCRIPTION
Adds tox to run python version compatibility tests locally.
Updates gitlab ci script to run the tests in Python 3.9 through 3.13 environments.
#144 